### PR TITLE
Add .so file extension

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -329,6 +329,7 @@
 		"lib": "file.lib",
 		"o": "file.binary",
 		"a": "file.lib",
+		"so": "file.lib",
 		"zip": "file.zip",
 		"tar": "file.zip",
 		"gz": "file.zip",


### PR DESCRIPTION
Simply use `file.lib` icon for `.so` shared libraries in addition to the others
